### PR TITLE
Add trigger based device support

### DIFF
--- a/Arduino Code/BTHome.cpp
+++ b/Arduino Code/BTHome.cpp
@@ -160,7 +160,7 @@ void BTHome::sortSensorData() {
   }
 }
 
-void BTHome::buildPaket() {
+void BTHome::buildPaket(bool trigger_based_device) {
   //the Object ids have to be applied in numerical order (from low to high)
   if (this->m_sortEnable) sortSensorData();
 
@@ -206,7 +206,10 @@ void BTHome::buildPaket() {
   serviceData += UUID2;  // DO NOT CHANGE -- UUID
   // The encryption
   if (this->m_encryptEnable) {
-    serviceData += ENCRYPT;
+    if (trigger_based_device)
+      serviceData += ENCRYPT_TRIGGER_BASE;
+    else
+      serviceData += ENCRYPT;
 
     uint8_t ciphertext[BLE_ADVERT_MAX_LEN];
     uint8_t encryptionTag[MIC_LEN];
@@ -239,7 +242,10 @@ void BTHome::buildPaket() {
     serviceData += encryptionTag[3];
   }
   else {
-    serviceData += NO_ENCRYPT;
+    if (trigger_based_device)
+      serviceData += NO_ENCRYPT_TRIGGER_BASE;
+    else
+      serviceData += NO_ENCRYPT;
     for (i = 0; i < this->m_sensorDataIdx; i++)
     {
       serviceData += this->m_sensorData[i]; // Add the sensor data to the Service Data

--- a/Arduino Code/BTHome.h
+++ b/Arduino Code/BTHome.h
@@ -18,7 +18,9 @@
 #define SERVICE_DATA 0x16
 
 #define NO_ENCRYPT 0x40
+#define NO_ENCRYPT_TRIGGER_BASE 0x44
 #define ENCRYPT 0x41
+#define ENCRYPT_TRIGGER_BASE 0x45
 
 #define SHORT_NAME 0x08
 #define COMPLETE_NAME 0x09
@@ -114,7 +116,7 @@ class BTHome {
     void begin(String dname = "DIY-sensor", bool encryption = false, uint8_t const* const key = NULL);
     void begin(String dname = "DIY-sensor", bool encryption = false, String key = "");
     void setDeviceName(String dname = "");
-    void buildPaket();
+    void buildPaket(bool trigger_based_device = false);
     void start(uint32_t duration = 0);
     void stop();
     bool isAdvertising();


### PR DESCRIPTION
From bthome.io:
The trigger based device flag is telling the receiver that it should expect that the device is sending BLE advertisements at a regular interval (bit 2 = 0) or at an irregular interval (bit 2 = 1), e.g. only when someone pushes a button. This can be usefull information for a receiver, e.g. to prevent the device from going to unavailable.

Make the device into a sleepy sensors and prevent it from going to unavailable, just call buildPaket(true).
