### PR TITLE
Fix call of function bthome.begin()

### DIFF
--- a/Arduino Code/BTHome.ino
+++ b/Arduino Code/BTHome.ino
@@ -19,9 +19,9 @@ BTHome bthome;
 void setup() {
   Serial.begin(115200);
 #ifdef ENABLE_ENCRYPT
-  bthome.begin(DEVICE_NAME, true, BIND_KEY);
+  bthome.begin(DEVICE_NAME, true, BIND_KEY, false);
 #else
-  bthome.begin(DEVICE_NAME);
+  bthome.begin(DEVICE_NAME, false, "", false);
 #endif
 }
 


### PR DESCRIPTION
Fixed the encryption and none-encryption call of bthome.begin(). 

trigger_based_device defaulted to false.